### PR TITLE
Render the metadata-block correctly inside other volto blocks

### DIFF
--- a/src/components/manage/Blocks/Metadata/Edit.jsx
+++ b/src/components/manage/Blocks/Metadata/Edit.jsx
@@ -13,34 +13,41 @@ export const EditMetadataBlock = (props) => {
     onChangeBlock,
     onChangeField,
     properties,
+    metadata
   } = props;
-  const [metadata, setMetadata] = useState(data?.data?.id);
+  const [metadata_id, setMetadata_id] = useState(data?.data?.id);
   const schema = useSelector((state) => state?.schema?.schema || {});
+  let metadata_element = {}
+  metadata ? (
+    metadata_element = { ...metadata }
+  ):(
+    metadata_element = { ...properties }
+  )
 
   const onMetadataSelect = React.useCallback(
     (event, select) => {
       const { value } = select;
       onChangeBlock(block, { ...data, data: value });
-      setMetadata(value.id);
+      setMetadata_id(value.id);
     },
     [block, data, onChangeBlock],
   );
 
-  const field = schema.properties ? schema.properties[metadata] : {};
-  const required = schema?.required?.includes(metadata);
+  const field = schema.properties ? schema.properties[metadata_id] : {};
+  const required = schema?.required?.includes(metadata_id);
 
   return (
     <div className={cx('block metadata', { selected: selected })}>
       {field ? (
         <Field
           {...field}
-          id={metadata}
-          value={properties[metadata]}
+          id={metadata_id}
+          value={metadata_element[metadata_id]}
           required={required}
           onChange={(id, value) => {
             onChangeField(id, value);
           }}
-          key={metadata}
+          key={metadata_id}
           block={block}
         />
       ) : (

--- a/src/components/manage/Blocks/Metadata/Edit.jsx
+++ b/src/components/manage/Blocks/Metadata/Edit.jsx
@@ -13,16 +13,14 @@ export const EditMetadataBlock = (props) => {
     onChangeBlock,
     onChangeField,
     properties,
-    metadata
+    metadata,
   } = props;
   const [metadata_id, setMetadata_id] = useState(data?.data?.id);
   const schema = useSelector((state) => state?.schema?.schema || {});
-  let metadata_element = {}
-  metadata ? (
-    metadata_element = { ...metadata }
-  ):(
-    metadata_element = { ...properties }
-  )
+  let metadata_element = {};
+  metadata
+    ? (metadata_element = { ...metadata })
+    : (metadata_element = { ...properties });
 
   const onMetadataSelect = React.useCallback(
     (event, select) => {

--- a/src/components/manage/Blocks/Metadata/View.jsx
+++ b/src/components/manage/Blocks/Metadata/View.jsx
@@ -10,11 +10,9 @@ export const ViewMetadataBlock = (props) => {
   let metadata_element = { ...initialFormData };
 
   const { properties, metadata } = props;
-  metadata ? (
-    metadata_element = { ...metadata }
-    ):(
-      metadata_element = { ...properties }
-    )
+  metadata
+    ? (metadata_element = { ...metadata })
+    : (metadata_element = { ...properties });
 
   if (!data?.id) {
     return '';

--- a/src/components/manage/Blocks/Metadata/View.jsx
+++ b/src/components/manage/Blocks/Metadata/View.jsx
@@ -7,18 +7,20 @@ export const ViewMetadataBlock = (props) => {
   const { data } = props.data;
   const { views } = config.widgets;
   const initialFormData = useSelector((state) => state?.content?.data || {});
-  let metadata = { ...initialFormData };
+  let metadata_element = { ...initialFormData };
 
-  const { properties } = props;
-  if (properties) {
-    metadata = { ...properties };
-  }
+  const { properties, metadata } = props;
+  metadata ? (
+    metadata_element = { ...metadata }
+    ):(
+      metadata_element = { ...properties }
+    )
 
   if (!data?.id) {
     return '';
   }
 
-  let output = metadata[data.id];
+  let output = metadata_element[data.id];
   let Widget = views?.getWidget(data);
   if (!output && props.data.placeholder) {
     Widget = views?.default;


### PR DESCRIPTION
The volto-metadata-block is not rendering correctly the content inside other blocks (I used [volto-columns-block](https://github.com/eea/volto-columns-block/) and 12.10.1 version of Volto for the example):

![volto-metadata-bug](https://user-images.githubusercontent.com/5443301/116697254-3eaa5800-a9c3-11eb-905a-87d50a55b961.gif)

Inside one block, the used data comes on the props.metadata instead of props.properties, so I've modified the Edit.jsx and View.jsx files to use the props.metadata property when it comes.

![volto-metadata-bugfix](https://user-images.githubusercontent.com/5443301/116697811-ee7fc580-a9c3-11eb-9fc9-e23f526a5526.gif)

This way, we can use volto-metadata-block inside other blocks.

See the issue: https://github.com/eea/volto-metadata-block/issues/3