### PR TITLE
feat: Add Cypress E2E tests

### DIFF
--- a/cypress/e2e/03-blocks-metadata-view.cy.js
+++ b/cypress/e2e/03-blocks-metadata-view.cy.js
@@ -1,0 +1,25 @@
+import { slateBeforeEach, slateAfterEach } from '../support/e2e';
+
+describe('Metadata Block: View Mode Tests', () => {
+  beforeEach(slateBeforeEach);
+  afterEach(slateAfterEach);
+
+  it('Metadata Block: Add and save', () => {
+    cy.clearSlateTitle();
+    cy.getSlateTitle().type('Metadata View Test');
+    cy.get('.documentFirstHeading').contains('Metadata View Test');
+
+    cy.getSlate().click();
+
+    // Add Metadata block
+    cy.get('.ui.basic.icon.button.block-add-button').first().click();
+    cy.get('.blocks-chooser .title').contains('Common').click();
+    cy.get('.content.active.common .button.metadata')
+      .contains('Metadata')
+      .click({ force: true });
+
+    // Save
+    cy.get('#toolbar-save').click();
+    cy.contains('Metadata View Test');
+  });
+});

--- a/cypress/e2e/03-blocks-metadata-view.cy.js
+++ b/cypress/e2e/03-blocks-metadata-view.cy.js
@@ -1,25 +1,45 @@
 import { slateBeforeEach, slateAfterEach } from '../support/e2e';
 
+const setPageTitle = (title) => {
+  cy.clearSlateTitle();
+  cy.getSlateTitle().type(title);
+  cy.get('.documentFirstHeading').contains(title);
+};
+
+const addMetadataBlock = () => {
+  cy.getSlate().click();
+  cy.get('.ui.basic.icon.button.block-add-button').first().click();
+  cy.get('.blocks-chooser .title').contains('Common').click();
+  cy.get('.content.active.common .button.metadata')
+    .contains('Metadata')
+    .click({ force: true });
+};
+
 describe('Metadata Block: View Mode Tests', () => {
   beforeEach(slateBeforeEach);
   afterEach(slateAfterEach);
 
-  it('Metadata Block: Add and save', () => {
-    cy.clearSlateTitle();
-    cy.getSlateTitle().type('Metadata View Test');
-    cy.get('.documentFirstHeading').contains('Metadata View Test');
+  it('updates rendered metadata value after editing an existing metadata block', () => {
+    setPageTitle('Metadata View Update Test');
+    addMetadataBlock();
 
-    cy.getSlate().click();
+    cy.get('.block.metadata input').click().type('Summary{enter}');
+    cy.get('.block.metadata textarea').click().type('First summary value');
 
-    // Add Metadata block
-    cy.get('.ui.basic.icon.button.block-add-button').first().click();
-    cy.get('.blocks-chooser .title').contains('Common').click();
-    cy.get('.content.active.common .button.metadata')
-      .contains('Metadata')
-      .click({ force: true });
-
-    // Save
     cy.get('#toolbar-save').click();
-    cy.contains('Metadata View Test');
+    cy.url().should('eq', `${Cypress.config().baseUrl}/cypress/my-page`);
+    cy.get('.block.metadata').contains('First summary value');
+
+    cy.visit('/cypress/my-page/edit');
+    cy.get('.block.metadata textarea')
+      .click()
+      .type('{selectAll}{backspace}')
+      .type('Updated summary value');
+
+    cy.get('#toolbar-save').click();
+    cy.url().should('eq', `${Cypress.config().baseUrl}/cypress/my-page`);
+
+    cy.get('.block.metadata').contains('Updated summary value');
+    cy.contains('First summary value').should('not.exist');
   });
 });


### PR DESCRIPTION
Added Cypress E2E test coverage for `volto-metadata-block`. All tests passing on Volto 18.